### PR TITLE
Reset switch if pan gesture is less than half slide

### DIFF
--- a/DGRunkeeperSwitch/DGRunkeeperSwitch.swift
+++ b/DGRunkeeperSwitch/DGRunkeeperSwitch.swift
@@ -12,7 +12,7 @@ import UIKit
 // MARK: DGRunkeeperSwitchRoundedLayer
 
 public class DGRunkeeperSwitchRoundedLayer: CALayer {
-
+    
     override public var frame: CGRect {
         didSet { cornerRadius = bounds.height / 2.0 }
     }
@@ -23,7 +23,7 @@ public class DGRunkeeperSwitchRoundedLayer: CALayer {
 // MARK: DGRunkeeperSwitch
 
 public class DGRunkeeperSwitch: UIControl {
-
+    
     // MARK: -
     // MARK: Public vars
     
@@ -89,7 +89,7 @@ public class DGRunkeeperSwitch: UIControl {
     
     // MARK: -
     // MARK: Constructors
-
+    
     public init(leftTitle: String!, rightTitle: String!) {
         super.init(frame: CGRect.zero)
         
@@ -98,7 +98,7 @@ public class DGRunkeeperSwitch: UIControl {
         
         finishInit()
     }
-
+    
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         
@@ -190,7 +190,6 @@ public class DGRunkeeperSwitch: UIControl {
             selectedBackgroundView.frame = frame
         } else if gesture.state == .Ended || gesture.state == .Failed || gesture.state == .Cancelled {
             let velocityX = gesture.velocityInView(self).x
-            
             if velocityX > 500.0 {
                 setSelectedIndex(1, animated: true)
             } else if velocityX < -500.0 {
@@ -204,13 +203,22 @@ public class DGRunkeeperSwitch: UIControl {
     }
     
     public func setSelectedIndex(selectedIndex: Int, animated: Bool) {
+        
+        // Reset switch on half pan gestures
+        var catchHalfSwitch:Bool = false
+        if self.selectedIndex == selectedIndex {
+            catchHalfSwitch = true
+        }
+        
         self.selectedIndex = selectedIndex
         if animated {
             UIView.animateWithDuration(animationDuration, delay: 0.0, usingSpringWithDamping: animationSpringDamping, initialSpringVelocity: animationInitialSpringVelocity, options: [UIViewAnimationOptions.BeginFromCurrentState, UIViewAnimationOptions.CurveEaseOut], animations: { () -> Void in
                 self.layoutSubviews()
                 }, completion: { (finished) -> Void in
                     if finished {
-                        self.sendActionsForControlEvents(.ValueChanged)
+                        if (!catchHalfSwitch) {
+                            self.sendActionsForControlEvents(.ValueChanged)
+                        }
                     }
             })
         } else {


### PR DESCRIPTION
This fixes the switch not reseting when you perform a pan gesture that doesn't trigger a value change.

![switchfix](https://cloud.githubusercontent.com/assets/6370613/11688989/b54b6818-9e5d-11e5-9370-2803df7e3ade.gif)
